### PR TITLE
Ability to pass string values as padding parameter

### DIFF
--- a/src/smith.js
+++ b/src/smith.js
@@ -48,7 +48,7 @@ function Spritesmith(params, callback) {
   // Create our smiths
   var engineSmith = new EngineSmith(engine),
       layer = new Layout(algorithmPref),
-      padding = params.padding || 0,
+      padding = parseInt(params.padding, 10) || 0,
       exportOpts = params.exportOpts || {},
       packedObj;
 


### PR DESCRIPTION
Prevents error when passed padding is string ('20px', '20' instead of number 20)
