### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /src-test/actual_files
 /scratch
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint src/ src-test/ --max-warnings 0",
     "test": "npm run precheck && mocha src-test/ --timeout 60000 --reporter dot && npm run lint"
   },
+  "overrides": { "tough-cookie": "~4.1.3" },
   "dependencies": {
     "concat-stream": "~1.5.1",
     "layout": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "lint": "eslint src/ src-test/ --max-warnings 0",
     "test": "npm run precheck && mocha src-test/ --timeout 60000 --reporter dot && npm run lint"
   },
-  "overrides": { "tough-cookie": "~4.1.3" },
   "dependencies": {
     "concat-stream": "~1.5.1",
     "layout": "~2.2.0",

--- a/src-test/smith_test.js
+++ b/src-test/smith_test.js
@@ -199,7 +199,7 @@ describe('An empty array', function () {
 
     it('has no errors', spritesmithUtils.assertNoError());
     it('renders an empty spritesheet', function () {
-      assert.deepEqual(this.result.image, new Buffer(0));
+      assert.deepEqual(this.result.image, Buffer.alloc(0));
     });
     it('returns an empty coordinate mapping', function () {
       assert.deepEqual(this.result.coordinates, {});


### PR DESCRIPTION
* ~resolve moderate severity npm audit warning with tough-cookie override~
* fix deprecation warning message for tests by updating Buffer
* add package-lock to .gitignore